### PR TITLE
feat(browse): add default behavior for non-file buffers

### DIFF
--- a/lua/pbrowse.lua
+++ b/lua/pbrowse.lua
@@ -1,5 +1,15 @@
 local M = {}
 
+local function open_url(url)
+  if vim.fn.has('mac') == 1 then
+    vim.fn.system('open ' .. vim.fn.shellescape(url))
+  elseif vim.fn.has('unix') == 1 then
+    vim.fn.system('xdg-open ' .. vim.fn.shellescape(url))
+  else
+    vim.api.nvim_err_writeln("Unsupported platform for opening URL")
+  end
+end
+
 function M.browse(line1, line2, range)
   if vim.fn.has('win32') == 1 or vim.fn.has('win64') == 1 then
     vim.api.nvim_err_writeln("Windows is not supported. Please use WSL (Windows Subsystem for Linux) instead.")
@@ -8,8 +18,16 @@ function M.browse(line1, line2, range)
 
   -- Get current PR URL using gh command
   local pr_url = vim.fn.trim(vim.fn.system('gh pr view --json url --jq .url'))
+  local pr_files_url = pr_url .. '/files'
   if vim.v.shell_error ~= 0 then
     vim.api.nvim_err_writeln("Failed to get PR URL. Make sure you're in a git repository with an active PR and gh CLI is installed.")
+    return
+  end
+
+  -- Get full path of current file
+  local full_path = vim.fn.expand('%:p')
+  if vim.fn.filereadable(full_path) == 0 then
+    open_url(pr_files_url)
     return
   end
 
@@ -21,7 +39,6 @@ function M.browse(line1, line2, range)
   end
 
   -- Get full path of current file and make it relative to git root
-  local full_path = vim.fn.expand('%:p')
   local git_root_path = git_root .. '/'
   local file_path = full_path
   if full_path:sub(1, #git_root_path) == git_root_path then
@@ -35,7 +52,7 @@ function M.browse(line1, line2, range)
   local file_hash = vim.fn.sha256(file_path)
   
   -- Build the URL
-  local url = pr_url .. '/files#diff-' .. file_hash
+  local url = pr_files_url .. '#diff-' .. file_hash
   
   -- Add line information only if it's a selection or a specific line
   if range > 0 then
@@ -46,13 +63,7 @@ function M.browse(line1, line2, range)
     end
   end
   
-  if vim.fn.has('mac') == 1 then
-    vim.fn.system('open ' .. vim.fn.shellescape(url))
-  elseif vim.fn.has('unix') == 1 then
-    vim.fn.system('xdg-open ' .. vim.fn.shellescape(url))
-  else
-    vim.api.nvim_err_writeln("Unsupported platform for opening URL")
-  end
+  open_url(url)
 end
 
 return M

--- a/lua/pbrowse.lua
+++ b/lua/pbrowse.lua
@@ -18,33 +18,17 @@ function M.browse(line1, line2, range)
 
   -- Get current PR URL using gh command
   local pr_url = vim.fn.trim(vim.fn.system('gh pr view --json url --jq .url'))
-  local pr_files_url = pr_url .. '/files'
   if vim.v.shell_error ~= 0 then
     vim.api.nvim_err_writeln("Failed to get PR URL. Make sure you're in a git repository with an active PR and gh CLI is installed.")
     return
   end
+  local pr_files_url = pr_url .. '/files'
 
-  -- Get full path of current file
+  -- Get relative path from the project root of current file
   local full_path = vim.fn.expand('%:p')
-  if vim.fn.filereadable(full_path) == 0 then
+  local file_path = vim.fn.trim(vim.fn.system('git ls-files --full-name -- ' .. vim.fn.shellescape(full_path)))
+  if vim.v.shell_error ~= 0 or file_path == "" then
     open_url(pr_files_url)
-    return
-  end
-
-  -- Get git root directory
-  local git_root = vim.fn.trim(vim.fn.system('git rev-parse --show-toplevel'))
-  if vim.v.shell_error ~= 0 then
-    vim.api.nvim_err_writeln("Failed to get git root directory. Make sure you're in a git repository.")
-    return
-  end
-
-  -- Get full path of current file and make it relative to git root
-  local git_root_path = git_root .. '/'
-  local file_path = full_path
-  if full_path:sub(1, #git_root_path) == git_root_path then
-    file_path = full_path:sub(#git_root_path + 1)
-  else
-    vim.api.nvim_err_writeln("Current file is not within the git repository")
     return
   end
 


### PR DESCRIPTION
When browsing a PR from a buffer that is not a readable file, now automatically redirects to the PR files view instead of failing. This improves the workflow when running the command from other buffers.

Also refactors the URL opening logic into a separate function to avoid code duplication and makes other minor code improvements.